### PR TITLE
Dependencies to 'raspell' (not 'dmarkow-raspell') in your gemspec file

### DIFF
--- a/thinking-sphinx-raspell.gemspec
+++ b/thinking-sphinx-raspell.gemspec
@@ -40,18 +40,18 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<thinking-sphinx>, [">= 1.2.12"])
-      s.add_runtime_dependency(%q<raspell>, [">= 1.1"])
+      s.add_runtime_dependency(%q<dmarkow-raspell>, [">= 1.1"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<yard>, [">= 0"])
     else
       s.add_dependency(%q<thinking-sphinx>, [">= 1.2.12"])
-      s.add_dependency(%q<raspell>, [">= 1.1"])
+      s.add_dependency(%q<dmarkow-raspell>, [">= 1.1"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<yard>, [">= 0"])
     end
   else
     s.add_dependency(%q<thinking-sphinx>, [">= 1.2.12"])
-    s.add_dependency(%q<raspell>, [">= 1.1"])
+    s.add_dependency(%q<dmarkow-raspell>, [">= 1.1"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<yard>, [">= 0"])
   end


### PR DESCRIPTION
It seems, you still have dependencies to 'raspell' (not 'dmarkow-raspell') in your gemspec file. If i change them, everything works fine. This is the commit I changed it.
